### PR TITLE
Fix: Warnings in run

### DIFF
--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -296,7 +296,7 @@ class DockerCLI extends Adapter
         (empty($command) ? "" : " ".implode(" ", $command))
             , '', $stdout, $stderr, 30);
 
-        if (!empty($stderr) || $result !== 0) {
+        if ($result !== 0) {
             throw new Orchestration("Docker Error: {$stderr}");
         }
 


### PR DESCRIPTION
Currently in `run`, of a warning occurs (text in stderr), it will result as failed, which is not true. We should only use exit code to determine if execution failed or not.