### PR TITLE
Feat: Usage Stats

### DIFF
--- a/src/Orchestration/Adapter.php
+++ b/src/Orchestration/Adapter.php
@@ -88,7 +88,7 @@ abstract class Adapter
      * @param string $container
      * @param array<string, string> $filters
      * 
-     * @return array
+     * @return array<Stats>
      */
     abstract public function getStats(string $container = null, array $filters = []): array;
 

--- a/src/Orchestration/Adapter.php
+++ b/src/Orchestration/Adapter.php
@@ -86,10 +86,11 @@ abstract class Adapter
      * Get usage stats of containers
      * 
      * @param string $container
+     * @param array<string, string> $filters
      * 
      * @return array
      */
-    abstract public function getStats(string $container = null): array;
+    abstract public function getStats(string $container = null, array $filters = []): array;
 
     /**
      * Pull Image

--- a/src/Orchestration/Adapter.php
+++ b/src/Orchestration/Adapter.php
@@ -83,6 +83,15 @@ abstract class Adapter
     abstract public function listNetworks(): array;
 
     /**
+     * Get usage stats of containers
+     * 
+     * @param string $container
+     * 
+     * @return array
+     */
+    abstract public function getStats(string $container = null): array;
+
+    /**
      * Pull Image
      * 
      * @param string $image

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -6,6 +6,7 @@ use CurlHandle;
 use stdClass;
 use Utopia\Orchestration\Adapter;
 use Utopia\Orchestration\Container;
+use Utopia\Orchestration\Container\Stats;
 use Utopia\Orchestration\Exception\Orchestration;
 use Utopia\Orchestration\Exception\Timeout;
 use Utopia\Orchestration\Network;
@@ -284,7 +285,7 @@ class DockerAPI extends Adapter
      * @param string $container
      * @param array<string, string> $filters
      * 
-     * @return array
+     * @return array<Stats>
      */
     public function getStats(string $container = null, array $filters = []): array
     {
@@ -319,15 +320,15 @@ class DockerAPI extends Adapter
                 $networkOut += $network['tx_bytes'];
             }
 
-            $list[] = [
-                'id' => $stats['id'],
-                'name' => \ltrim($stats['name'], '/'), // Remove '/' prefix
-                'cpu' => 1, // TODO: Implement (API seems to give incorrect values)
-                'memory' => ($stats['memory_stats']['usage'] / $stats['memory_stats']['limit']) * 100.0,
-                'diskIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (API does not provide these values)
-                'memoryIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (API does not provide these values
-                'networkIO' => [ 'in' => $networkIn, 'out' => $networkOut ],
-            ];
+            $list[] = new Stats(
+                containerId: $stats['id'],
+                containerName: \ltrim($stats['name'], '/'), // Remove '/' prefix
+                cpuUsage:1, // TODO: Implement (API seems to give incorrect values)
+                memoryUsage: ($stats['memory_stats']['usage'] / $stats['memory_stats']['limit']) * 100.0,
+                diskIO: [ 'in' => 0, 'out' => 0 ], // TODO: Implement (API does not provide these values)
+                memoryIO: [ 'in' => 0, 'out' => 0 ], // TODO: Implement (API does not provide these values
+                networkIO: [ 'in' => $networkIn, 'out' => $networkOut ],
+            );
         }
 
         return $list;

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -330,8 +330,6 @@ class DockerAPI extends Adapter
                 $networkOut += $network['tx_bytes'];
             }
 
-            // Rx means Receive, and Tx means
-
             $list[] = [
                 'id' => $stats['id'],
                 'name' => \ltrim($stats['name'], '/'), // Remove '/' prefix

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -311,6 +311,12 @@ class DockerAPI extends Adapter
             $cpuDelta = $stats['cpu_stats']['cpu_usage']['total_usage'] - $stats['precpu_stats']['cpu_usage']['total_usage'];
             $systemCpuDelta = $stats['cpu_stats']['system_cpu_usage']  - $stats['precpu_stats']['system_cpu_usage'];
 
+            \var_dump($stats);
+            \var_dump($cpuDelta);
+            \var_dump($systemCpuDelta);
+            \var_dump($stats['cpu_stats']['online_cpus']);
+            \var_dump(($cpuDelta / $systemCpuDelta) * $stats['cpu_stats']['online_cpus'] * 100.0);
+
             $networkIn = 0;
             $networkOut = 0;
             foreach ($stats['networks'] as $network) {

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -338,8 +338,9 @@ class DockerAPI extends Adapter
                 'cpu' => 1, // TODO: Implement (I coudl not do it because Docker API does not give correct values)
                 // 'cpu' => ($cpuDelta / $systemCpuDelta) * $stats['cpu_stats']['online_cpus'] * 100.0,
                 'memory' => ($stats['memory_stats']['usage'] / $stats['memory_stats']['limit']) * 100.0,
-                'diskIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (I could not find it in API)
-                'memoryIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (I could not find it in API)
+                'diskIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (API does not provide these values)
+                'memoryIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (API does not provide these values
+)
                 'networkIO' => [ 'in' => $networkIn, 'out' => $networkOut ],
             ];
         }

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -3,6 +3,7 @@
 namespace Utopia\Orchestration\Adapter;
 
 use CurlHandle;
+use Exception;
 use stdClass;
 use Utopia\Orchestration\Adapter;
 use Utopia\Orchestration\Container;
@@ -276,6 +277,18 @@ class DockerAPI extends Adapter
         }
 
         return $result['code'] == 200;
+    }
+
+    /**
+     * Get usage stats of containers
+     * 
+     * @param string $container
+     * 
+     * @return array
+     */
+    public function getStats(string $container = null): array
+    {
+        throw new Exception("Method not implemented yet.");
     }
 
     /**

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -282,16 +282,28 @@ class DockerAPI extends Adapter
      * Get usage stats of containers
      * 
      * @param string $container
+     * @param array<string, string> $filters
      * 
      * @return array
      */
-    public function getStats(string $container = null): array
+    public function getStats(string $container = null, array $filters = []): array
     {
         // List ahead of time, since API does not allow listing all usage stats
         $containerIds = [];
 
         if($container === null) {
-            $containers = \json_decode($this->call('http://localhost/containers/json', 'GET')['response'], true);
+            $filtersSorted = [];
+
+            foreach($filters as $key => $value) {
+                $filtersSorted[$key] = [$value];
+            }
+    
+            $body = [
+                'all' => true,
+                'filters' => empty($filtersSorted) ? new stdClass() : json_encode($filtersSorted)
+            ];
+
+            $containers = \json_decode($this->call('http://localhost/containers/json?'.\http_build_query($body), 'GET')['response'], true);
             $containerIds = \array_map(fn($c) => $c['Id'], $containers);
         } else {
             $containerIds[] = $container;

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -3,7 +3,6 @@
 namespace Utopia\Orchestration\Adapter;
 
 use CurlHandle;
-use Exception;
 use stdClass;
 use Utopia\Orchestration\Adapter;
 use Utopia\Orchestration\Container;

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -311,12 +311,6 @@ class DockerAPI extends Adapter
             $cpuDelta = $stats['cpu_stats']['cpu_usage']['total_usage'] - $stats['precpu_stats']['cpu_usage']['total_usage'];
             $systemCpuDelta = $stats['cpu_stats']['system_cpu_usage']  - $stats['precpu_stats']['system_cpu_usage'];
 
-            \var_dump($stats);
-            \var_dump($cpuDelta);
-            \var_dump($systemCpuDelta);
-            \var_dump($stats['cpu_stats']['online_cpus']);
-            \var_dump(($cpuDelta / $systemCpuDelta) * $stats['cpu_stats']['online_cpus'] * 100.0);
-
             $networkIn = 0;
             $networkOut = 0;
             foreach ($stats['networks'] as $network) {
@@ -329,7 +323,8 @@ class DockerAPI extends Adapter
             $list[] = [
                 'id' => $stats['id'],
                 'name' => \ltrim($stats['name'], '/'), // Remove '/' prefix
-                'cpu' => ($cpuDelta / $systemCpuDelta) * $stats['cpu_stats']['online_cpus'] * 100.0,
+                'cpu' => 1, // TODO: Implement (I coudl not do it because Docker API does not give correct values)
+                // 'cpu' => ($cpuDelta / $systemCpuDelta) * $stats['cpu_stats']['online_cpus'] * 100.0,
                 'memory' => ($stats['memory_stats']['usage'] / $stats['memory_stats']['limit']) * 100.0,
                 'diskIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (I could not find it in API)
                 'memoryIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (I could not find it in API)

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -292,19 +292,8 @@ class DockerAPI extends Adapter
         $containerIds = [];
 
         if($container === null) {
-            $filtersSorted = [];
-
-            foreach($filters as $key => $value) {
-                $filtersSorted[$key] = [$value];
-            }
-    
-            $body = [
-                'all' => true,
-                'filters' => empty($filtersSorted) ? new stdClass() : json_encode($filtersSorted)
-            ];
-
-            $containers = \json_decode($this->call('http://localhost/containers/json?'.\http_build_query($body), 'GET')['response'], true);
-            $containerIds = \array_map(fn($c) => $c['Id'], $containers);
+            $containers = $this->list($filters);
+            $containerIds = \array_map(fn($c) => $c->getId(), $containers);
         } else {
             $containerIds[] = $container;
         }
@@ -333,12 +322,10 @@ class DockerAPI extends Adapter
             $list[] = [
                 'id' => $stats['id'],
                 'name' => \ltrim($stats['name'], '/'), // Remove '/' prefix
-                'cpu' => 1, // TODO: Implement (I coudl not do it because Docker API does not give correct values)
-                // 'cpu' => ($cpuDelta / $systemCpuDelta) * $stats['cpu_stats']['online_cpus'] * 100.0,
+                'cpu' => 1, // TODO: Implement (API seems to give incorrect values)
                 'memory' => ($stats['memory_stats']['usage'] / $stats['memory_stats']['limit']) * 100.0,
                 'diskIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (API does not provide these values)
                 'memoryIO' => [ 'in' => 0, 'out' => 0 ], // TODO: Implement (API does not provide these values
-)
                 'networkIO' => [ 'in' => $networkIn, 'out' => $networkOut ],
             ];
         }

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -148,6 +148,10 @@ class DockerCLI extends Adapter
             $containerIds[] = $container;
         }
 
+        if(\count($containerIds) <= 0 && \count($filters) > 0) {
+            return []; // No containers found
+        }
+
         $stats = [];
 
         $containersString = "";

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -134,11 +134,15 @@ class DockerCLI extends Adapter
 
                 $stdoutArray = \explode("\n", $stdout);
 
-                $containerIds = \array_map(function($row) {
-                    $container = [];
-                    \parse_str($row, $container);
-                    return $container['id'];
-                }, $stdoutArray);
+                foreach($stdoutArray as $row) {
+                    if(empty($row)) {
+                        continue;
+                    }
+
+                    $rowParsed = [];
+                    \parse_str($row, $rowParsed);
+                    $containerIds[] = $rowParsed['id'];
+                }
             }
         } else {
             $containerIds[] = $container;

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -2,7 +2,6 @@
 
 namespace Utopia\Orchestration\Adapter;
 
-use Exception;
 use Utopia\CLI\Console;
 use Utopia\Orchestration\Adapter;
 use Utopia\Orchestration\Container;

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -170,8 +170,8 @@ class DockerCLI extends Adapter
 
      /**
      * Use this method to parse string format into numeric in&out stats.
-     * CLI IO stats in verbose format: 2.133MiB / 62.8GiB
-     * Outpit after parsing: [ "in" => 2133000, "out": 62800000000 ]
+     * CLI IO stats in verbose format: "2.133MiB / 62.8GiB"
+     * Output after parsing: [ "in" => 2133000, "out" => 62800000000 ]
      * 
      * @return array<string,float>
      */

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -5,6 +5,7 @@ namespace Utopia\Orchestration\Adapter;
 use Utopia\CLI\Console;
 use Utopia\Orchestration\Adapter;
 use Utopia\Orchestration\Container;
+use Utopia\Orchestration\Container\Stats;
 use Utopia\Orchestration\Exception\Orchestration;
 use Utopia\Orchestration\Exception\Timeout;
 use Utopia\Orchestration\Network;
@@ -108,7 +109,7 @@ class DockerCLI extends Adapter
      * @param string $container
      * @param array<string, string> $filters
      * 
-     * @return array
+     * @return array<Stats>
      */
     public function getStats(string $container = null, array $filters = []): array
     {
@@ -153,15 +154,15 @@ class DockerCLI extends Adapter
             $stat = [];
             \parse_str($line, $stat);
 
-            $stats[] = [
-                'id' => $stat['id'],
-                'name' => $stat['name'],
-                'cpu' => \floatval(\rtrim($stat['cpu'], '%')) / 100, // Remove percentage symbol, parse to number, convert to percentage
-                'memory' => empty($stat['memory']) ? 0 : \floatval(\rtrim($stat['memory'], '%')), // Remove percentage symbol and parse to number. Value is empty on Windows
-                'diskIO' => $this->parseIOStats($stat['diskIO']),
-                'memoryIO' => $this->parseIOStats($stat['memoryIO']),
-                'networkIO' => $this->parseIOStats($stat['networkIO']),
-            ];
+            $stats[] = new Stats(
+                containerId: $stat['id'],
+                containerName: $stat['name'],
+                cpuUsage: \floatval(\rtrim($stat['cpu'], '%')) / 100, // Remove percentage symbol, parse to number, convert to percentage
+                memoryUsage: empty($stat['memory']) ? 0 : \floatval(\rtrim($stat['memory'], '%')), // Remove percentage symbol and parse to number. Value is empty on Windows
+                diskIO: $this->parseIOStats($stat['diskIO']),
+                memoryIO: $this->parseIOStats($stat['memoryIO']),
+                networkIO: $this->parseIOStats($stat['networkIO']),
+            );
         }
 
         return $stats;

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -106,17 +106,24 @@ class DockerCLI extends Adapter
      * Get usage stats of containers
      * 
      * @param string $container
+     * @param array<string, string> $filters
      * 
      * @return array
      */
-    public function getStats(string $container = null): array
+    public function getStats(string $container = null, array $filters = []): array
     {
         $stats = [];
 
         $stdout = '';
         $stderr = '';
 
-        $result = Console::execute('docker stats --no-trunc --format "id={{.ID}}&name={{.Name}}&cpu={{.CPUPerc}}&memory={{.MemPerc}}&diskIO={{.BlockIO}}&memoryIO={{.MemUsage}}&networkIO={{.NetIO}}" --no-stream ' . $container, '', $stdout, $stderr);
+        $filterString = '';
+
+        foreach($filters as $key => $value) {
+            $filterString = $filterString . ' --filter "'.$key.'='.$value.'"';
+        }
+
+        $result = Console::execute('docker stats --no-trunc --format "id={{.ID}}&name={{.Name}}&cpu={{.CPUPerc}}&memory={{.MemPerc}}&diskIO={{.BlockIO}}&memoryIO={{.MemUsage}}&networkIO={{.NetIO}}" --no-stream' . $filterString . ' ' . $container, '', $stdout, $stderr);
         
         if($result !== 0) {
             throw new Orchestration("Docker Error: {$stderr}");

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -170,13 +170,12 @@ class DockerCLI extends Adapter
 
      /**
      * Use this method to parse string format into numeric in&out stats.
-     * CLI IO stats in verbose format: 2.203MiB / 62.8GiB
-     * Outpit after parsing: [ "in" => 2.203, "out": 62.8 ]
+     * CLI IO stats in verbose format: 2.133MiB / 62.8GiB
+     * Outpit after parsing: [ "in" => 2133000, "out": 62800000000 ]
      * 
      * @return array<string,float>
      */
     private function parseIOStats(string $stats) {
-        \var_dump($stats);
         $units = [
             'B' => 1,
             'KB' => 1000,
@@ -213,8 +212,6 @@ class DockerCLI extends Adapter
             'in' => $inValue * $inMultiply,
             'out' => $outValue * $outMultiply,
         ];
-        \var_dump($response);
-        \var_dump('---');
 
         return $response;
     }

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -135,7 +135,7 @@ class DockerCLI extends Adapter
             $stats[] = [
                 'id' => $stat['id'],
                 'name' => $stat['name'],
-                'cpu' => \floatval(\rtrim($stat['cpu'], '%')), // Remove percentage symbol and parse to number
+                'cpu' => \floatval(\rtrim($stat['cpu'], '%')) / 100, // Remove percentage symbol, parse to number, convert to percentage
                 'memory' => empty($stat['memory']) ? 0 : \floatval(\rtrim($stat['memory'], '%')), // Remove percentage symbol and parse to number. Value is empty on Windows
                 'diskIO' => $this->parseIOStats($stat['diskIO']),
                 'memoryIO' => $this->parseIOStats($stat['memoryIO']),

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -170,11 +170,13 @@ class DockerCLI extends Adapter
 
      /**
      * Use this method to parse string format into numeric in&out stats.
-     * CLI provides IO stats in verbose format like '12.5GiB / 10.01KiB'.
+     * CLI IO stats in verbose format: 2.203MiB / 62.8GiB
+     * Outpit after parsing: [ "in" => 2.203, "out": 62.8 ]
      * 
      * @return array<string,float>
      */
     private function parseIOStats(string $stats) {
+        \var_dump($stats);
         $units = [
             'B' => 1,
             'KB' => 1000,
@@ -193,7 +195,7 @@ class DockerCLI extends Adapter
         $inUnit = null;
         $outUnit = null;
 
-        foreach ($units as $unit) {
+        foreach ($units as $unit => $value) {
             if(\str_ends_with($inStr, $unit)) {
                 $inUnit = $unit;
             } else if(\str_ends_with($outStr, $unit)) {
@@ -211,6 +213,8 @@ class DockerCLI extends Adapter
             'in' => $inValue * $inMultiply,
             'out' => $outValue * $outMultiply,
         ];
+        \var_dump($response);
+        \var_dump('---');
 
         return $response;
     }

--- a/src/Orchestration/Container/Stats.php
+++ b/src/Orchestration/Container/Stats.php
@@ -1,0 +1,89 @@
+<?php
+namespace Utopia\Orchestration\Container;
+
+class Stats {
+    protected string $containerId;
+    protected string $containerName;
+
+    protected float $cpuUsage;
+    protected float $memoryUsage;
+
+    /**
+     * @var array<string,float>
+     */
+    protected array $diskIO;
+    
+    /**
+     * @var array<string,float>
+     */
+    protected array $memoryIO;
+
+    /**
+     * @var array<string,float>
+     */
+    protected array $networkIO;
+
+    /**
+     * @param string $containerId
+     * @param string $containerName
+     * @param float $cpuUsage
+     * @param float $memoryUsage
+     * @param array<string,float> $diskIO
+     * @param array<string,float> $memoryIO
+     * @param array<string,float> $networkIO
+     */
+    public function __construct(string $containerId, string $containerName, float $cpuUsage, float $memoryUsage, array $diskIO, array $memoryIO, array $networkIO)
+    {
+        $this->containerId = $containerId;
+        $this->containerName = $containerName;
+        $this->cpuUsage = $cpuUsage;
+        $this->memoryUsage = $memoryUsage;
+        $this->diskIO = $diskIO;
+        $this->memoryIO = $memoryIO;
+        $this->networkIO = $networkIO;
+    }
+
+    public function getContainerId(): string 
+    {
+        return $this->containerId;
+    }
+
+    public function getContainerName(): string 
+    {
+        return $this->containerName;
+    }
+
+    public function getCpuUsage(): float 
+    {
+        return $this->cpuUsage;
+    }
+
+    public function getMemoryUsage(): float 
+    {
+        return $this->memoryUsage;
+    }
+
+    /**
+     * @return array<string,float>
+     */
+    public function getMemoryIO(): array 
+    {
+        return $this->memoryIO;
+    }
+
+    /**
+     * @return array<string,float>
+     */
+    public function getDiskIO(): array 
+    {
+        return $this->diskIO;
+    }
+    /**
+     * @return array<string,float>
+     */
+    public function getNetworkIO(): array 
+    {
+        return $this->networkIO;
+    }
+
+}

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -133,19 +133,15 @@ class Orchestration
      * Get usage stats of containers
      * 
      * @param string $container
-     * @param int $duration
+     * @param int $cycles
      * 
      * @return array
      */
-    public function getStats(string $container = null, int $duration = 2): array 
+    public function getStats(string $container = null, int $cycles = 1): array 
     {
-        if($duration % 2 !== 0) {
-            throw new ExceptionOrchestration("Duration has to be multiples of 2.");
-        }
-
         $averageStats = [];
 
-        for ($i = 0; $i < $duration; $i += 2) {
+        for ($i = 0; $i < $cycles; $i++) {
             $averageStats[] = $this->adapter->getStats($container);
         }
 

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -165,7 +165,7 @@ class Orchestration
 
         $i = 0;
         foreach ($containerIds as $containerId) {
-            $container = $averageStats[0][$i];
+            $stat = $averageStats[0][$i];
 
             $averageCpu = 0;
             $averageMemory = 0;
@@ -199,8 +199,8 @@ class Orchestration
             $averageNetworkIO['out'] /= $statsCount; 
 
             $response[] = new Stats(
-                containerId: $container['id'],
-                containerName: $container['name'],
+                containerId: $stat->getContainerId(),
+                containerName: $stat->getContainerId(),
                 cpuUsage: $averageCpu,
                 memoryUsage: $averageMemory,
                 diskIO: $averageDiskIO,

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -160,7 +160,10 @@ class Orchestration
         $containerIds = \array_map(fn($stat) => $stat['id'], $averageStats[0]);
         $response = [];
 
+        $i = 0;
         foreach ($containerIds as $containerId) {
+            $container = $averageStats[0][$i];
+
             $averageCpu = 0;
             $averageMemory = 0;
             $averageDiskIO = [ 'in' => 0, 'out' => 0 ];
@@ -180,7 +183,7 @@ class Orchestration
                 $averageMemoryIO['in'] += ($stat['memoryIO'] ?? $emptyIO)['in'];
                 $averageMemoryIO['out'] += ($stat['memoryIO'] ?? $emptyIO)['out'];
                 $averageNetworkIO['in'] += ($stat['networkIO'] ?? $emptyIO)['in'];
-                $averageNetworkIO['ou'] += ($stat['networkIO'] ?? $emptyIO)['out'];
+                $averageNetworkIO['out'] += ($stat['networkIO'] ?? $emptyIO)['out'];
             }
     
             $statsCount = \count($stat);
@@ -195,14 +198,16 @@ class Orchestration
             $averageNetworkIO['out'] /= $statsCount; 
 
             $response[] = [
-                'id' => $averageStats[0]['id'],
-                'name' => $averageStats[0]['name'],
+                'id' => $container['id'],
+                'name' => $container['name'],
                 'cpu' => $averageCpu,
                 'memory' => $averageMemory,
                 'diskIO' => $averageDiskIO,
                 'memoryIO' => $averageMemoryIO,
                 'networkIO' => $averageNetworkIO
             ];
+
+            $i++;
         }
 
       

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -186,7 +186,7 @@ class Orchestration
                 $averageNetworkIO['out'] += ($stat['networkIO'] ?? $emptyIO)['out'];
             }
     
-            $statsCount = \count($stat);
+            $statsCount = \count($averageStats);
     
             $averageCpu /= $statsCount;
             $averageMemory /= $statsCount;

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -129,6 +129,18 @@ class Orchestration
     }
 
     /**
+     * Get usage stats of containers
+     * 
+     * @param string $container
+     * 
+     * @return array
+     */
+    public function getStats(string $container = null): array 
+    {
+        return $this->adapter->getStats($container);
+    }
+
+    /**
      * Disconnect a container from a network
      * 
      * @param string $container

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -163,9 +163,11 @@ class Orchestration
         foreach ($containerIds as $containerId) {
             $averageCpu = 0;
             $averageMemory = 0;
-            $averageDiskIO = 0;
-            $averageMemoryIO = 0;
-            $averageNetworkIO = 0;
+            $averageDiskIO = [ 'in' => 0, 'out' => 0 ];
+            $averageMemoryIO = [ 'in' => 0, 'out' => 0 ];
+            $averageNetworkIO = [ 'in' => 0, 'out' => 0 ];
+
+            $emptyIO = [ 'in' => 0, 'out' => 0 ]; // Used as default value
     
             foreach ($averageStats as $statArr) {
                 $statIndex = \array_search($containerId, \array_map(fn ($statI) => $statI['id'], $statArr));
@@ -173,18 +175,24 @@ class Orchestration
                 
                 $averageCpu += $stat['cpu'] ?? 0;
                 $averageMemory += $stat['memory'] ?? 0;
-                $averageDiskIO += $stat['diskIO'] ?? 0;
-                $averageMemoryIO += $stat['memoryIO'] ?? 0;
-                $averageNetworkIO += $stat['networkIO'] ?? 0;
+                $averageDiskIO['in'] += ($stat['diskIO'] ?? $emptyIO)['in'];
+                $averageDiskIO['out'] += ($stat['diskIO'] ?? $emptyIO)['out'];
+                $averageMemoryIO['in'] += ($stat['memoryIO'] ?? $emptyIO)['in'];
+                $averageMemoryIO['out'] += ($stat['memoryIO'] ?? $emptyIO)['out'];
+                $averageNetworkIO['in'] += ($stat['networkIO'] ?? $emptyIO)['in'];
+                $averageNetworkIO['ou'] += ($stat['networkIO'] ?? $emptyIO)['out'];
             }
     
             $statsCount = \count($stat);
     
             $averageCpu /= $statsCount;
             $averageMemory /= $statsCount;
-            $averageDiskIO /= $statsCount;
-            $averageMemoryIO /= $statsCount;
-            $averageNetworkIO /= $statsCount; 
+            $averageDiskIO['in'] /= $statsCount;
+            $averageDiskIO['out'] /= $statsCount;
+            $averageMemoryIO['in'] /= $statsCount;
+            $averageMemoryIO['out'] /= $statsCount;
+            $averageNetworkIO['in'] /= $statsCount; 
+            $averageNetworkIO['out'] /= $statsCount; 
 
             $response[] = [
                 'id' => $averageStats[0]['id'],

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -133,16 +133,17 @@ class Orchestration
      * Get usage stats of containers
      * 
      * @param string $container
+     * @param array<string, string> $filters
      * @param int $cycles
      * 
      * @return array
      */
-    public function getStats(string $container = null, int $cycles = 1): array 
+    public function getStats(string $container = null, array $filters = [], int $cycles = 1): array 
     {
         $averageStats = [];
 
         for ($i = 0; $i < $cycles; $i++) {
-            $averageStats[] = $this->adapter->getStats($container);
+            $averageStats[] = $this->adapter->getStats($container, $filters);
         }
 
         return $averageStats[0]; // TODO: Average results

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -200,7 +200,7 @@ class Orchestration
 
             $response[] = new Stats(
                 containerId: $stat->getContainerId(),
-                containerName: $stat->getContainerId(),
+                containerName: $stat->getContainerName(),
                 cpuUsage: $averageCpu,
                 memoryUsage: $averageMemory,
                 diskIO: $averageDiskIO,

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -138,7 +138,7 @@ class Orchestration
      * 
      * @return array<Stats>
      */
-    public function getStats(string $container = null, array $filters = [], int $cycles = 1): array 
+    public function getStats(string $container = null, array $filters = [], int $cycles = 2): array 
     {
         /**
          * @var array<Stats>

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -4,6 +4,7 @@ namespace Utopia\Orchestration;
 
 use Utopia\Orchestration\Adapter;
 use Exception;
+use Utopia\Orchestration\Exception\Orchestration as ExceptionOrchestration;
 
 class Orchestration
 {
@@ -132,12 +133,23 @@ class Orchestration
      * Get usage stats of containers
      * 
      * @param string $container
+     * @param int $duration
      * 
      * @return array
      */
-    public function getStats(string $container = null): array 
+    public function getStats(string $container = null, int $duration = 2): array 
     {
-        return $this->adapter->getStats($container);
+        if($duration % 2 !== 0) {
+            throw new ExceptionOrchestration("Duration has to be multiples of 2.");
+        }
+
+        $averageStats = [];
+
+        for ($i = 0; $i < $duration; $i += 2) {
+            $averageStats[] = $this->adapter->getStats($container);
+        }
+
+        return $averageStats[0]; // TODO: Average results
     }
 
     /**

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -39,8 +39,10 @@ abstract class Base extends TestCase
          */
         $response = static::getOrchestration()->pull('appwrite/runtime-for-php:8.0');
 
+        $this->assertEquals(true, $response);
+
         // Used later for CPU usage test
-        $response = static::getOrchestration()->pull('containerstack/alpine-stress');
+        $response = static::getOrchestration()->pull('containerstack/alpine-stress:latest');
 
         $this->assertEquals(true, $response);
 
@@ -350,7 +352,6 @@ abstract class Base extends TestCase
      * @return void
      * @depends testCreateContainer
      */
-
     public function testListFilters(): void
     {
         $response = $this->getOrchestration()->list(['id' => self::$containerID]);

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -517,7 +517,7 @@ abstract class Base extends TestCase
         $this->assertEquals('UsageStats2', $stats[0]['name']);
 
         $this->assertGreaterThanOrEqual(0, $stats[0]['cpu']);
-        $this->assertLessThanOrEqual(1, $stats[0]['cpu']);
+        $this->assertLessThanOrEqual(2, $stats[0]['cpu']); // Sometimes it gives like 102% usage
 
         $this->assertGreaterThanOrEqual(0, $stats[0]['memory']);
         $this->assertLessThanOrEqual(1, $stats[0]['memory']);

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -554,8 +554,14 @@ abstract class Base extends TestCase
         $this->assertEquals($stats[0]['id'], $stats2[0]['id']);
         $this->assertEquals($stats[0]['name'], $stats2[0]['name']);
 
-        $this->assertGreaterThanOrEqual(0.9, $stats[0]['cpu']);
-        $this->assertGreaterThanOrEqual(0.9, $stats[1]['cpu']);
+        $this->assertGreaterThanOrEqual(0.5, $stats[0]['cpu']);
+        $this->assertGreaterThanOrEqual(0.5, $stats[1]['cpu']);
+
+        $timeStart = \time();
+        static::getOrchestration()->getStats(duration: 4);
+        $timeEnd = \time();
+        \var_dump($timeEnd - $timeStart);
+        $this->assertGreaterThanOrEqual(4, $timeEnd - $timeStart);
 
         $response = static::getOrchestration()->remove('UsageStats1', true);
 

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -456,12 +456,6 @@ abstract class Base extends TestCase
      * @depends testPullImage
      */
     public function testUsageStats(): void {
-        // Skip tests for Docker CLI - not implemented yet
-        if (static::getAdapterName() === "Docker API") {
-            $this->assertTrue(true);
-            return;
-        }
-
         /**
          * Test for Success
          */
@@ -477,6 +471,11 @@ abstract class Base extends TestCase
                 '-c',
                 'tail -f /dev/null'
             ],
+            '',
+            '/usr/local/src/',
+            [],
+            [],
+            __DIR__ . '/Resources',
         );
 
         $this->assertNotEmpty($containerId1);
@@ -496,13 +495,34 @@ abstract class Base extends TestCase
         $stats = static::getOrchestration()->getStats();
 
         $this->assertCount(2, $stats);
+
         $this->assertNotEmpty($stats[0]['id']);
-        $this->assertNotEmpty($stats[0]['name']);
-        $this->assertNotEmpty($stats[0]['cpu']);
-        $this->assertNotEmpty($stats[0]['memory']);
-        $this->assertNotEmpty($stats[0]['diskIO']);
-        $this->assertNotEmpty($stats[0]['memoryIO']);
-        $this->assertNotEmpty($stats[0]['networkIO']);
+        $this->assertEquals(64, \strlen($stats[0]['id']));
+
+        $this->assertEquals('UsageStats2', $stats[0]['name']);
+
+        $this->assertIsFloat($stats[0]['cpu']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]['cpu']);
+        $this->assertLessThanOrEqual(1, $stats[0]['cpu']);
+
+        $this->assertIsFloat($stats[0]['memory']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]['memory']);
+        $this->assertLessThanOrEqual(1, $stats[0]['memory']);
+
+        $this->assertIsNumeric($stats[0]['diskIO']['in']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]['diskIO']['in']);
+        $this->assertIsNumeric($stats[0]['diskIO']['out']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]['diskIO']['out']);
+
+        $this->assertIsNumeric($stats[0]['memoryIO']['in']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]['memoryIO']['in']);
+        $this->assertIsNumeric($stats[0]['memoryIO']['out']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]['memoryIO']['out']);
+
+        $this->assertIsNumeric($stats[0]['networkIO']['in']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]['networkIO']['in']);
+        $this->assertIsNumeric($stats[0]['networkIO']['out']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]['networkIO']['out']);
 
         $stats1 = static::getOrchestration()->getStats($containerId1);
         $stats2 = static::getOrchestration()->getStats($containerId2);

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -513,31 +513,31 @@ abstract class Base extends TestCase
 
         $this->assertCount(2, $stats);
 
-        $this->assertNotEmpty($stats[0]['id']);
-        $this->assertEquals(64, \strlen($stats[0]['id']));
+        $this->assertNotEmpty($stats[0]->getContainerId());
+        $this->assertEquals(64, \strlen($stats[0]->getContainerId()));
 
-        $this->assertEquals('UsageStats2', $stats[0]['name']);
+        $this->assertEquals('UsageStats2', $stats[0]->getContainerName());
 
-        $this->assertGreaterThanOrEqual(0, $stats[0]['cpu']);
-        $this->assertLessThanOrEqual(2, $stats[0]['cpu']); // Sometimes it gives like 102% usage
+        $this->assertGreaterThanOrEqual(0, $stats[0]->getCpuUsage());
+        $this->assertLessThanOrEqual(2, $stats[0]->getCpuUsage()); // Sometimes it gives like 102% usage
 
-        $this->assertGreaterThanOrEqual(0, $stats[0]['memory']);
-        $this->assertLessThanOrEqual(1, $stats[0]['memory']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]->getMemoryUsage());
+        $this->assertLessThanOrEqual(1, $stats[0]->getMemoryUsage());
 
-        $this->assertIsNumeric($stats[0]['diskIO']['in']);
-        $this->assertGreaterThanOrEqual(0, $stats[0]['diskIO']['in']);
-        $this->assertIsNumeric($stats[0]['diskIO']['out']);
-        $this->assertGreaterThanOrEqual(0, $stats[0]['diskIO']['out']);
+        $this->assertIsNumeric($stats[0]->getDiskIO()['in']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]->getDiskIO()['in']);
+        $this->assertIsNumeric($stats[0]->getDiskIO()['out']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]->getDiskIO()['out']);
 
-        $this->assertIsNumeric($stats[0]['memoryIO']['in']);
-        $this->assertGreaterThanOrEqual(0, $stats[0]['memoryIO']['in']);
-        $this->assertIsNumeric($stats[0]['memoryIO']['out']);
-        $this->assertGreaterThanOrEqual(0, $stats[0]['memoryIO']['out']);
+        $this->assertIsNumeric($stats[0]->getMemoryIO()['in']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]->getMemoryIO()['in']);
+        $this->assertIsNumeric($stats[0]->getMemoryIO()['out']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]->getMemoryIO()['out']);
 
-        $this->assertIsNumeric($stats[0]['networkIO']['in']);
-        $this->assertGreaterThanOrEqual(0, $stats[0]['networkIO']['in']);
-        $this->assertIsNumeric($stats[0]['networkIO']['out']);
-        $this->assertGreaterThanOrEqual(0, $stats[0]['networkIO']['out']);
+        $this->assertIsNumeric($stats[0]->getNetworkIO()['in']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]->getNetworkIO()['in']);
+        $this->assertIsNumeric($stats[0]->getNetworkIO()['out']);
+        $this->assertGreaterThanOrEqual(0, $stats[0]->getNetworkIO()['out']);
 
         $stats1 = static::getOrchestration()->getStats($containerId1);
         $stats2 = static::getOrchestration()->getStats($containerId2);
@@ -545,22 +545,22 @@ abstract class Base extends TestCase
         $statsName1 = static::getOrchestration()->getStats('UsageStats1');
         $statsName2 = static::getOrchestration()->getStats('UsageStats2');
 
-        $this->assertEquals($statsName1[0]['id'], $stats1[0]['id']);
-        $this->assertEquals($statsName1[0]['name'], $stats1[0]['name']);
-        $this->assertEquals($statsName2[0]['name'], $stats2[0]['name']);
-        $this->assertEquals($statsName2[0]['name'], $stats2[0]['name']);
+        $this->assertEquals($statsName1[0]->getContainerId(), $stats1[0]->getContainerId());
+        $this->assertEquals($statsName1[0]->getContainerName(), $stats1[0]->getContainerName());
+        $this->assertEquals($statsName2[0]->getContainerName(), $stats2[0]->getContainerName());
+        $this->assertEquals($statsName2[0]->getContainerName(), $stats2[0]->getContainerName());
 
-        $this->assertEquals($stats[1]['id'], $stats1[0]['id']);
-        $this->assertEquals($stats[1]['name'], $stats1[0]['name']);
-        $this->assertEquals($stats[0]['id'], $stats2[0]['id']);
-        $this->assertEquals($stats[0]['name'], $stats2[0]['name']);
+        $this->assertEquals($stats[1]->getContainerId(), $stats1[0]->getContainerId());
+        $this->assertEquals($stats[1]->getContainerName(), $stats1[0]->getContainerName());
+        $this->assertEquals($stats[0]->getContainerId(), $stats2[0]->getContainerId());
+        $this->assertEquals($stats[0]->getContainerName(), $stats2[0]->getContainerName());
 
-        $this->assertGreaterThanOrEqual(0.5, $stats[0]['cpu']);
-        $this->assertGreaterThanOrEqual(0.5, $stats[1]['cpu']);
+        $this->assertGreaterThanOrEqual(0.5, $stats[0]->getCpuUsage());
+        $this->assertGreaterThanOrEqual(0.5, $stats[1]->getCpuUsage());
 
         $statsFiltered = static::getOrchestration()->getStats(filters: ['label' => 'utopia-container-type=stats']);
         $this->assertCount(1, $statsFiltered);
-        $this->assertEquals($containerId1, $statsFiltered[0]['id']);
+        $this->assertEquals($containerId1, $statsFiltered[0]->getContainerId());
 
         $statsFiltered = static::getOrchestration()->getStats(filters: ['label' => 'utopia-container-type=non-existing-type']);
         $this->assertCount(0, $statsFiltered);

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -553,8 +553,8 @@ abstract class Base extends TestCase
         $this->assertEquals($stats[0]['id'], $stats2[0]['id']);
         $this->assertEquals($stats[0]['name'], $stats2[0]['name']);
 
-        $this->assertGreaterThanOrEqual(0.9, $stats2[0]['cpu']);
-        $this->assertGreaterThanOrEqual(0.9, $stats2[1]['cpu']);
+        $this->assertGreaterThanOrEqual(0.9, $stats[0]['cpu']);
+        $this->assertGreaterThanOrEqual(0.9, $stats[1]['cpu']);
 
         $response = static::getOrchestration()->remove('UsageStats1', true);
 

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -562,6 +562,9 @@ abstract class Base extends TestCase
         $this->assertCount(1, $statsFiltered);
         $this->assertEquals($containerId1, $statsFiltered[0]['id']);
 
+        $statsFiltered = static::getOrchestration()->getStats(filters: ['label' => 'utopia-container-type=non-existing-type']);
+        $this->assertCount(0, $statsFiltered);
+
         $timeStart = \time();
         static::getOrchestration()->getStats(cycles: 2); // 4s on CLI, 4s per container on API
         $timeEnd = \time();

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -516,11 +516,9 @@ abstract class Base extends TestCase
 
         $this->assertEquals('UsageStats2', $stats[0]['name']);
 
-        $this->assertIsFloat($stats[0]['cpu']);
         $this->assertGreaterThanOrEqual(0, $stats[0]['cpu']);
         $this->assertLessThanOrEqual(1, $stats[0]['cpu']);
 
-        $this->assertIsFloat($stats[0]['memory']);
         $this->assertGreaterThanOrEqual(0, $stats[0]['memory']);
         $this->assertLessThanOrEqual(1, $stats[0]['memory']);
 

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -39,6 +39,9 @@ abstract class Base extends TestCase
          */
         $response = static::getOrchestration()->pull('appwrite/runtime-for-php:8.0');
 
+        // Used later for CPU usage test
+        $response = static::getOrchestration()->pull('containerstack/alpine-stress');
+
         $this->assertEquals(true, $response);
 
         /**

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -558,9 +558,8 @@ abstract class Base extends TestCase
         $this->assertGreaterThanOrEqual(0.5, $stats[1]['cpu']);
 
         $timeStart = \time();
-        static::getOrchestration()->getStats(duration: 4);
+        static::getOrchestration()->getStats(cycles: 2); // 4s on CLI, 4s per container on API
         $timeEnd = \time();
-        \var_dump($timeEnd - $timeStart);
         $this->assertGreaterThanOrEqual(4, $timeEnd - $timeStart);
 
         $response = static::getOrchestration()->remove('UsageStats1', true);

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -555,8 +555,8 @@ abstract class Base extends TestCase
         $this->assertEquals($stats[0]['id'], $stats2[0]['id']);
         $this->assertEquals($stats[0]['name'], $stats2[0]['name']);
 
-        \var_dump($stats[0]['cpu']);
-        \var_dump($stats[1]['cpu']);
+        $this->assertGreaterThanOrEqual(0.9, $stats2[0]['cpu']);
+        $this->assertGreaterThanOrEqual(0.9, $stats2[1]['cpu']);
 
         $response = static::getOrchestration()->remove('UsageStats1', true);
 

--- a/tests/Orchestration/Base.php
+++ b/tests/Orchestration/Base.php
@@ -480,6 +480,7 @@ abstract class Base extends TestCase
             ],
             workdir: '/usr/local/src/',
             mountFolder: __DIR__ . '/Resources',
+            labels: [ 'utopia-container-type' => 'stats' ]
         );
 
         $this->assertNotEmpty($containerId1);
@@ -556,6 +557,10 @@ abstract class Base extends TestCase
 
         $this->assertGreaterThanOrEqual(0.5, $stats[0]['cpu']);
         $this->assertGreaterThanOrEqual(0.5, $stats[1]['cpu']);
+
+        $statsFiltered = static::getOrchestration()->getStats(filters: ['label' => 'utopia-container-type=stats']);
+        $this->assertCount(1, $statsFiltered);
+        $this->assertEquals($containerId1, $statsFiltered[0]['id']);
 
         $timeStart = \time();
         static::getOrchestration()->getStats(cycles: 2); // 4s on CLI, 4s per container on API


### PR DESCRIPTION
Usage stats are useful in Appwrite in future functions proxy. These stats will allow us to decide which function container to use or if we need to spawn a new one.

This implements `getStats()` that gives CPU, memory, disk, and network usage.

This is a per-container implementation of a similar implementation from utopia/system. Notice that the System library gives host machine stats while this gives per-container stats.

- [x] Implement tests