### PR TITLE
Fix: Missing chunks

### DIFF
--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -138,9 +138,10 @@ class DockerAPI extends Adapter
             $rawStream = unpack('C*', $str);
             $stream = $rawStream[1]; // 1-based index, not 0-based
 
-            if ($stream == 49) {
+            // Ascii encoding support
+            if ($stream === \ord("1")) {
                 $stream = 1;
-            } elseif ($stream == 50) {
+            } elseif ($stream === \ord("2")) {
                 $stream = 2;
             }
 

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -137,6 +137,13 @@ class DockerAPI extends Adapter
 
             $rawStream = unpack('C*', $str);
             $stream = $rawStream[1]; // 1-based index, not 0-based
+
+            if ($stream == 49) {
+                $stream = 1;
+            } elseif ($stream == 50) {
+                $stream = 2;
+            }
+
             switch ($stream) { // only 1 or 2, as set while creating exec
                 case 1:
                     $packed = pack('C*', ...\array_slice($rawStream, 8));

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -139,9 +139,9 @@ class DockerAPI extends Adapter
             $stream = $rawStream[1]; // 1-based index, not 0-based
 
             // Ascii encoding support
-            if ($stream === \ord("1")) {
+            if ($stream === \ord('1')) {
                 $stream = 1;
-            } elseif ($stream === \ord("2")) {
+            } elseif ($stream === \ord('2')) {
                 $stream = 2;
             }
 


### PR DESCRIPTION
Chunks are sometimes missing in dockerapi adapter. Reason is because it because ascii encoded for the header. This converts it back to bytes

- [x] Manual testing in executor PR https://github.com/open-runtimes/executor/pull/93