### PR TITLE
Fix: CURL Chunk processing

### DIFF
--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -141,10 +141,10 @@ class DockerAPI extends Adapter
 
             $originalSize = \strlen($str);
 
-            while (! empty($str)) {
+            while (\strlen($str) > 0) {
                 if ($isHeader) {
                     $header = \unpack('Ctype/Cfill1/Cfill2/Cfill3/Nsize', $str);
-                    $str = \mb_strcut($str, 8, null);
+                    $str = \substr($str, 8, null);
                     $isHeader = false;
                     $currentHeader = $header;
                 } else {
@@ -152,8 +152,8 @@ class DockerAPI extends Adapter
                     $type = $currentHeader['type'];
 
                     if (\strlen($str) >= $size) {
-                        $currentData .= \mb_substr($str, 0, $size);
-                        $str = \mb_strcut($str, $size, null);
+                        $currentData .= \substr($str, 0, $size);
+                        $str = \substr($str, $size, null);
                         $isHeader = true;
                         $currentHeader = null;
 

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -139,21 +139,21 @@ class DockerAPI extends Adapter
                 return 0;
             }
 
-            $originalSize = \mb_strlen($str);
+            $originalSize = \strlen($str);
 
-            while (\mb_strlen($str) > 0) {
+            while (\strlen($str) > 0) {
                 if ($isHeader) {
                     $header = \unpack('Ctype/Cfill1/Cfill2/Cfill3/Nsize', $str);
-                    $str = \mb_strcut($str, 8, null);
+                    $str = \substr($str, 8, null);
                     $isHeader = false;
                     $currentHeader = $header;
                 } else {
                     $size = $currentHeader['size'];
                     $type = $currentHeader['type'];
 
-                    if (\mb_strlen($str) >= $size) {
-                        $currentData .= \mb_strcut($str, 0, $size);
-                        $str = \mb_strcut($str, $size, null);
+                    if (\strlen($str) >= $size) {
+                        $currentData .= \substr($str, 0, $size);
+                        $str = \strcut($str, $size, null);
                         $isHeader = true;
                         $currentHeader = null;
 
@@ -164,7 +164,7 @@ class DockerAPI extends Adapter
                         }
                         $currentData = '';
                     } else {
-                        $currentHeader['size'] -= \mb_strlen($str);
+                        $currentHeader['size'] -= \strlen($str);
                         $currentData .= $str;
                         $str = '';
                     }

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -139,7 +139,7 @@ class DockerAPI extends Adapter
                 return 0;
             }
 
-            $originalSize = \mb_strlen($str);
+            $originalSize = \strlen($str);
 
             while (! empty($str)) {
                 if ($isHeader) {
@@ -164,7 +164,7 @@ class DockerAPI extends Adapter
                         }
                         $currentData = '';
                     } else {
-                        $currentHeader['size'] -= \mb_strlen($str);
+                        $currentHeader['size'] -= \strlen($str);
                         $currentData .= $str;
                         $str = '';
                     }

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -153,7 +153,7 @@ class DockerAPI extends Adapter
 
                     if (\strlen($str) >= $size) {
                         $currentData .= \substr($str, 0, $size);
-                        $str = \strcut($str, $size, null);
+                        $str = \substr($str, $size, null);
                         $isHeader = true;
                         $currentHeader = null;
 

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -139,21 +139,21 @@ class DockerAPI extends Adapter
                 return 0;
             }
 
-            $originalSize = \strlen($str);
+            $originalSize = \mb_strlen($str);
 
-            while (\strlen($str) > 0) {
+            while (\mb_strlen($str) > 0) {
                 if ($isHeader) {
                     $header = \unpack('Ctype/Cfill1/Cfill2/Cfill3/Nsize', $str);
-                    $str = \substr($str, 8, null);
+                    $str = \mb_strcut($str, 8, null);
                     $isHeader = false;
                     $currentHeader = $header;
                 } else {
                     $size = $currentHeader['size'];
                     $type = $currentHeader['type'];
 
-                    if (\strlen($str) >= $size) {
-                        $currentData .= \substr($str, 0, $size);
-                        $str = \substr($str, $size, null);
+                    if (\mb_strlen($str) >= $size) {
+                        $currentData .= \mb_strcut($str, 0, $size);
+                        $str = \mb_strcut($str, $size, null);
                         $isHeader = true;
                         $currentHeader = null;
 
@@ -164,7 +164,7 @@ class DockerAPI extends Adapter
                         }
                         $currentData = '';
                     } else {
-                        $currentHeader['size'] -= \strlen($str);
+                        $currentHeader['size'] -= \mb_strlen($str);
                         $currentData .= $str;
                         $str = '';
                     }


### PR DESCRIPTION
Error:

    string(76) "Curl Error: Failure writing output to destination, passed 7622 returned 5402"

Warning: unpack(): Type C: not enough input values, need 1 values but only 0 were provided in /usr/local/vendor/utopia-php/orchestration/src/Orchestration/Adapter/DockerAPI.php on line 146

Afterwards, test that was throwing above errors consistently passed 3 times in a row:

![CleanShot 2024-08-13 at 20 40 51@2x](https://github.com/user-attachments/assets/becad3d6-9ede-4502-80d5-5517ec49a6da)
