### PR TITLE
Issue #46 Add Code Formatter and CI/CD Linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
 

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "scripts": {
-        "lint": "./vendor/bin/pint --test",
+        "lint": "./vendor/bin/pint --test --config pint.json",
         "test": "./vendor/bin/phpunit --configuration phpunit.xml",
         "check": "./vendor/bin/phpstan analyse --level 6 src tests",
-        "format": "./vendor/bin/pint"
+        "format": "./vendor/bin/pint --config pint.json"
     },
     "autoload": {
         "psr-4": {"Utopia\\Orchestration\\": "src/Orchestration"}


### PR DESCRIPTION
In response to issue #46, "Add code formatter and CI/CD linter", I configured Pint to the same settings as the Open Runtimes Executor repository. More specifically, I configured the lint and format scripts in the composer.json file with the pint.json file. I then updated "uses: actions/checkout@v3" to "uses: actions/checkout@v2" in the linter.yml file. Now the linter script runs and flags errors in new code when triggered by a pull request.