### PR TITLE
Fix PHP 8.5 curl_close() deprecation

### DIFF
--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -76,8 +76,6 @@ class DockerAPI extends Adapter
         $result = \curl_exec($ch);
         $responseCode = \curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
 
-        \curl_close($ch);
-
         return [
             'response' => $result,
             'code' => $responseCode,
@@ -187,8 +185,6 @@ class DockerAPI extends Adapter
                 throw new Orchestration('Curl Error: '.curl_error($ch));
             }
         }
-
-        \curl_close($ch);
 
         return [
             'response' => $result,


### PR DESCRIPTION
## Summary
- Remove no-op `\curl_close($ch)` calls in `Orchestration\Adapter\DockerAPI` that trigger `Deprecated` notices on PHP 8.5.

## Why
`curl_close()` has been a no-op since PHP 8.0 and is now formally deprecated in 8.5. The curl handle is freed when the variable goes out of scope.

## Test plan
- [x] `composer lint` (Pint) — pass
- [x] `composer check` (PHPStan L6) — pass