### PR TITLE
Add Docker mount value object

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Once you have initialised your Orchestration object the following methods can be
 
     - `volumes` [Array]
 
-        The volumes to attach to the container. String values are passed as legacy Docker volume binds. `Mount::bind(...)` and `Mount::volume(...)` values are rendered as Docker mounts. Docker volume subpaths must already exist; callers are responsible for preparing them before running the container.
+        The volumes to attach to the container. String values are passed as legacy Docker volume binds. `Mount::bind(...)` and `Mount::volume(...)` values are rendered as Docker mounts. For bind mounts, `subpath` is appended to the host source path. Docker volume subpaths use Docker's native subpath support and must already exist; callers are responsible for preparing them before running the container.
     
     - `env` [Array]
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ require_once 'vendor/autoload.php';
 
 use Utopia\Orchestration\Orchestration;
 use Utopia\Orchestration\Adapter\DockerCLI;
+use Utopia\Orchestration\Mount;
 
 // Initialise Orchestration with Docker CLI adapter.
 $orchestration = new Orchestration(new DockerCLI());
@@ -102,7 +103,11 @@ Once you have initialised your Orchestration object the following methods can be
         ['echo', 'hello world!'],
         'entrypoint',
         'workdir',
-        ['tmp:/tmp:rw', 'cooldirectory:/home/folder:rw'],
+        [
+            'tmp:/tmp:rw',
+            Mount::bind('/host/cache', '/cache'),
+            Mount::volume('openruntimes-build-cache', '/cache', subpath: 'cache-key'),
+        ],
         ['ENV_VAR' => 'value'],
         '/tmp',
         ['label' => 'value'],
@@ -139,7 +144,7 @@ Once you have initialised your Orchestration object the following methods can be
 
     - `volumes` [Array]
 
-        The volumes to attach to the container.
+        The volumes to attach to the container. String values are passed as legacy Docker volume binds. `Mount::bind(...)` and `Mount::volume(...)` values are rendered as Docker mounts. Docker volume subpaths must already exist; callers are responsible for preparing them before running the container.
     
     - `env` [Array]
 

--- a/src/Orchestration/Adapter.php
+++ b/src/Orchestration/Adapter.php
@@ -100,7 +100,7 @@ abstract class Adapter
      * On fail it will throw an exception.
      *
      * @param  string[]  $command
-     * @param  string[]  $volumes
+     * @param  array<int, string|Mount>  $volumes
      * @param  array<string, string>  $vars
      * @param  array<string, string>  $labels
      */

--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -8,6 +8,7 @@ use Utopia\Orchestration\Container;
 use Utopia\Orchestration\Container\Stats;
 use Utopia\Orchestration\Exception\Orchestration;
 use Utopia\Orchestration\Exception\Timeout;
+use Utopia\Orchestration\Mount;
 use Utopia\Orchestration\Network;
 
 class DockerAPI extends Adapter
@@ -475,7 +476,7 @@ class DockerAPI extends Adapter
      * On fail it will throw an exception.
      *
      * @param  string[]  $command
-     * @param  string[]  $volumes
+     * @param  array<int, string|Mount>  $volumes
      * @param  array<string, string>  $vars
      * @param  array<string, string>  $labels
      */
@@ -511,6 +512,17 @@ class DockerAPI extends Adapter
         $labels[$this->namespace.'-type'] = 'runtime';
         $labels[$this->namespace.'-created'] = (string) time();
 
+        $binds = [];
+        $mounts = [];
+
+        foreach ($volumes as $volume) {
+            if ($volume instanceof Mount) {
+                $mounts[] = $volume->toDockerAPI();
+            } else {
+                $binds[] = $volume;
+            }
+        }
+
         $body = [
             'Hostname' => $hostname,
             'Entrypoint' => $entrypoint,
@@ -520,7 +532,8 @@ class DockerAPI extends Adapter
             'Labels' => (object) $labels,
             'Env' => array_values($vars),
             'HostConfig' => [
-                'Binds' => $volumes,
+                'Binds' => $binds,
+                'Mounts' => $mounts,
                 'CpuQuota' => floatval($this->cpus) * 100000,
                 'CpuPeriod' => 100000,
                 'Memory' => intval($this->memory) * 1e+6, // Convert into bytes

--- a/src/Orchestration/Adapter/DockerCLI.php
+++ b/src/Orchestration/Adapter/DockerCLI.php
@@ -9,6 +9,7 @@ use Utopia\Orchestration\Container;
 use Utopia\Orchestration\Container\Stats;
 use Utopia\Orchestration\Exception\Orchestration;
 use Utopia\Orchestration\Exception\Timeout;
+use Utopia\Orchestration\Mount;
 use Utopia\Orchestration\Network;
 
 class DockerCLI extends Adapter
@@ -387,7 +388,7 @@ class DockerCLI extends Adapter
      * On fail it will throw an exception.
      *
      * @param  string[]  $command
-     * @param  string[]  $volumes
+     * @param  array<int, string|Mount>  $volumes
      * @param  array<string, string>  $vars
      * @param  array<string, string>  $labels
      */
@@ -409,6 +410,42 @@ class DockerCLI extends Adapter
         $output = '';
         $stderr = '';
 
+        $dockerCommand = $this->getRunCommand($image, $name, $command, $entrypoint, $workdir, $volumes, $vars, $mountFolder, $labels, $hostname, $remove, $network, $restart);
+
+        $result = Console::execute($dockerCommand, '', $output, $stderr, 30);
+
+        if ($result !== 0) {
+            $error = empty($stderr) ? $output : $stderr;
+            throw new Orchestration("Docker Error: {$error}");
+        }
+
+        // Use first line only, CLI can add warnings or other messages
+        $output = \explode("\n", $output)[0];
+
+        return rtrim($output);
+    }
+
+    /**
+     * @param  string[]  $command
+     * @param  array<int, string|Mount>  $volumes
+     * @param  array<string, string>  $vars
+     * @param  array<string, string>  $labels
+     */
+    protected function getRunCommand(
+        string $image,
+        string $name,
+        array $command = [],
+        string $entrypoint = '',
+        string $workdir = '',
+        array $volumes = [],
+        array $vars = [],
+        string $mountFolder = '',
+        array $labels = [],
+        string $hostname = '',
+        bool $remove = false,
+        string $network = '',
+        string $restart = self::RESTART_NO
+    ): Command {
         $time = time();
 
         $dockerCommand = new Command('docker');
@@ -451,7 +488,11 @@ class DockerCLI extends Adapter
         }
 
         foreach ($volumes as $volume) {
-            $dockerCommand->option('--volume', $volume);
+            if ($volume instanceof Mount) {
+                $dockerCommand->option('--mount', $volume->toDockerCLI());
+            } else {
+                $dockerCommand->option('--volume', $volume);
+            }
         }
 
         foreach ($labels as $labelKey => $label) {
@@ -477,17 +518,7 @@ class DockerCLI extends Adapter
             $dockerCommand->argument($value);
         }
 
-        $result = Console::execute($dockerCommand, '', $output, $stderr, 30);
-
-        if ($result !== 0) {
-            $error = empty($stderr) ? $output : $stderr;
-            throw new Orchestration("Docker Error: {$error}");
-        }
-
-        // Use first line only, CLI can add warnings or other messages
-        $output = \explode("\n", $output)[0];
-
-        return rtrim($output);
+        return $dockerCommand;
     }
 
     /**

--- a/src/Orchestration/Mount.php
+++ b/src/Orchestration/Mount.php
@@ -22,6 +22,9 @@ class Mount
         return new self(self::TYPE_BIND, $source, $target, $readOnly, $subpath);
     }
 
+    /**
+     * Docker volume subpaths use native volume subpath support. Docker requires the subpath to already exist.
+     */
     public static function volume(string $source, string $target, bool $readOnly = false, string $subpath = ''): self
     {
         return new self(self::TYPE_VOLUME, $source, $target, $readOnly, $subpath);
@@ -73,6 +76,7 @@ class Mount
             return $this->source;
         }
 
+        // Bind subpaths are regular host path suffixes, not Docker native subpaths.
         return \rtrim($this->source, '/').'/'.\ltrim($this->subpath, '/');
     }
 }

--- a/src/Orchestration/Mount.php
+++ b/src/Orchestration/Mount.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Utopia\Orchestration;
+
+class Mount
+{
+    public const TYPE_BIND = 'bind';
+
+    public const TYPE_VOLUME = 'volume';
+
+    private function __construct(
+        private string $type,
+        private string $source,
+        private string $target,
+        private bool $readOnly = false,
+        private string $subpath = ''
+    ) {
+    }
+
+    public static function bind(string $source, string $target, bool $readOnly = false, string $subpath = ''): self
+    {
+        return new self(self::TYPE_BIND, $source, $target, $readOnly, $subpath);
+    }
+
+    public static function volume(string $source, string $target, bool $readOnly = false, string $subpath = ''): self
+    {
+        return new self(self::TYPE_VOLUME, $source, $target, $readOnly, $subpath);
+    }
+
+    /**
+     * @return array<string, array<string, string>|bool|string>
+     */
+    public function toDockerAPI(): array
+    {
+        $mount = [
+            'Type' => $this->type,
+            'Source' => $this->getSource(),
+            'Target' => $this->target,
+            'ReadOnly' => $this->readOnly,
+        ];
+
+        if ($this->type === self::TYPE_VOLUME && $this->subpath !== '') {
+            $mount['VolumeOptions'] = [
+                'Subpath' => $this->subpath,
+            ];
+        }
+
+        return $mount;
+    }
+
+    public function toDockerCLI(): string
+    {
+        $mount = [
+            'type='.$this->type,
+            'source='.$this->getSource(),
+            'target='.$this->target,
+        ];
+
+        if ($this->readOnly) {
+            $mount[] = 'readonly';
+        }
+
+        if ($this->type === self::TYPE_VOLUME && $this->subpath !== '') {
+            $mount[] = 'volume-subpath='.$this->subpath;
+        }
+
+        return \implode(',', $mount);
+    }
+
+    private function getSource(): string
+    {
+        if ($this->type !== self::TYPE_BIND || $this->subpath === '') {
+            return $this->source;
+        }
+
+        return \rtrim($this->source, '/').'/'.\ltrim($this->subpath, '/');
+    }
+}

--- a/src/Orchestration/Orchestration.php
+++ b/src/Orchestration/Orchestration.php
@@ -159,7 +159,7 @@ class Orchestration
      * On fail it will throw an exception.
      *
      * @param  string[]  $command
-     * @param  string[]  $volumes
+     * @param  array<int, string|Mount>  $volumes
      * @param  array<string, string>  $labels
      * @param  array<string, string>  $vars
      */

--- a/tests/Orchestration/MountTest.php
+++ b/tests/Orchestration/MountTest.php
@@ -29,6 +29,40 @@ class MountTest extends TestCase
         );
     }
 
+    public function testBindSerialization(): void
+    {
+        $mount = Mount::bind('/host/path', '/container/path');
+
+        $this->assertSame([
+            'Type' => 'bind',
+            'Source' => '/host/path',
+            'Target' => '/container/path',
+            'ReadOnly' => false,
+        ], $mount->toDockerAPI());
+
+        $this->assertSame(
+            'type=bind,source=/host/path,target=/container/path',
+            $mount->toDockerCLI()
+        );
+    }
+
+    public function testBindSerializationWithSubpath(): void
+    {
+        $mount = Mount::bind('/host/path', '/container/path', subpath: 'sub');
+
+        $this->assertSame([
+            'Type' => 'bind',
+            'Source' => '/host/path/sub',
+            'Target' => '/container/path',
+            'ReadOnly' => false,
+        ], $mount->toDockerAPI());
+
+        $this->assertSame(
+            'type=bind,source=/host/path/sub,target=/container/path',
+            $mount->toDockerCLI()
+        );
+    }
+
     public function testDockerAPIRequestBodyIncludesMountsAndLegacyBinds(): void
     {
         $adapter = new MountTestDockerAPI();

--- a/tests/Orchestration/MountTest.php
+++ b/tests/Orchestration/MountTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Utopia\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Orchestration\Adapter\DockerAPI;
+use Utopia\Orchestration\Adapter\DockerCLI;
+use Utopia\Orchestration\Mount;
+
+class MountTest extends TestCase
+{
+    public function testVolumeSerialization(): void
+    {
+        $mount = Mount::volume('openruntimes-build-cache', '/cache', false, 'cache-key');
+
+        $this->assertSame([
+            'Type' => 'volume',
+            'Source' => 'openruntimes-build-cache',
+            'Target' => '/cache',
+            'ReadOnly' => false,
+            'VolumeOptions' => [
+                'Subpath' => 'cache-key',
+            ],
+        ], $mount->toDockerAPI());
+
+        $this->assertSame(
+            'type=volume,source=openruntimes-build-cache,target=/cache,volume-subpath=cache-key',
+            $mount->toDockerCLI()
+        );
+    }
+
+    public function testDockerAPIRequestBodyIncludesMountsAndLegacyBinds(): void
+    {
+        $adapter = new MountTestDockerAPI();
+
+        $adapter->run(
+            'ubuntu:latest',
+            'MountTestContainer',
+            volumes: [
+                '/host/path:/container/path:rw',
+                Mount::volume('openruntimes-build-cache', '/cache', false, 'cache-key'),
+            ]
+        );
+
+        $hostConfig = $adapter->createBody['HostConfig'];
+
+        $this->assertSame(['/host/path:/container/path:rw'], $hostConfig['Binds']);
+        $this->assertSame([
+            [
+                'Type' => 'volume',
+                'Source' => 'openruntimes-build-cache',
+                'Target' => '/cache',
+                'ReadOnly' => false,
+                'VolumeOptions' => [
+                    'Subpath' => 'cache-key',
+                ],
+            ],
+        ], $hostConfig['Mounts']);
+    }
+
+    public function testDockerCLIRendersMountsAndLegacyVolumes(): void
+    {
+        $adapter = new MountTestDockerCLI();
+
+        $arguments = $adapter->getRunArguments([
+            '/host/path:/container/path:rw',
+            Mount::volume('openruntimes-build-cache', '/cache', false, 'cache-key'),
+        ]);
+
+        $this->assertContains('--volume', $arguments);
+        $this->assertContains('/host/path:/container/path:rw', $arguments);
+        $this->assertContains('--mount', $arguments);
+        $this->assertContains('type=volume,source=openruntimes-build-cache,target=/cache,volume-subpath=cache-key', $arguments);
+    }
+}
+
+class MountTestDockerAPI extends DockerAPI
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public array $createBody = [];
+
+    /**
+     * @param  array<mixed>|bool|int|float|object|resource|string|null  $body
+     * @param  string[]  $headers
+     * @return array{response: mixed, code: mixed}
+     */
+    protected function call(string $url, string $method, $body = null, array $headers = [], int $timeout = -1): array
+    {
+        if ($method === 'GET' && str_contains($url, '/images/')) {
+            return ['response' => '{}', 'code' => 200];
+        }
+
+        if ($method === 'POST' && str_contains($url, '/containers/create')) {
+            $this->createBody = \json_decode((string) $body, true);
+
+            return ['response' => '{"Id":"container-id"}', 'code' => 201];
+        }
+
+        if ($method === 'POST' && str_contains($url, '/containers/container-id/start')) {
+            return ['response' => '', 'code' => 204];
+        }
+
+        return ['response' => '', 'code' => 500];
+    }
+}
+
+class MountTestDockerCLI extends DockerCLI
+{
+    /**
+     * @param  array<int, string|Mount>  $volumes
+     * @return string[]
+     */
+    public function getRunArguments(array $volumes): array
+    {
+        return $this->getRunCommand('ubuntu:latest', 'MountTestContainer', volumes: $volumes)->toArray();
+    }
+}


### PR DESCRIPTION
## Summary
- add Mount::bind() and Mount::volume() value object support
- render Mount objects as Docker API HostConfig.Mounts and Docker CLI --mount flags
- keep legacy string volumes as binds/--volume and document volume subpath behavior

## Tests
- ./vendor/bin/phpunit --configuration phpunit.xml tests/Orchestration/MountTest.php
- ./vendor/bin/phpstan analyse --level 6 src tests
- ./vendor/bin/pint --test