### PR TITLE
Return false for Docker API exec failures

### DIFF
--- a/src/Orchestration/Adapter/DockerAPI.php
+++ b/src/Orchestration/Adapter/DockerAPI.php
@@ -621,8 +621,12 @@ class DockerAPI extends Adapter
         }
 
         $parsedResponse = json_decode($result['response'], true);
-        if ($parsedResponse['Running'] === true || $parsedResponse['ExitCode'] !== 0) {
+        if ($parsedResponse['Running'] === true) {
             throw new Orchestration('Failed to execute command. Exit code: '.$parsedResponse['ExitCode']);
+        }
+
+        if ($parsedResponse['ExitCode'] !== 0) {
+            return false;
         }
 
         return true;

--- a/tests/Orchestration/Adapter/DockerAPITest.php
+++ b/tests/Orchestration/Adapter/DockerAPITest.php
@@ -31,4 +31,50 @@ class DockerAPITest extends Base
 
         return self::$orchestration = $orchestration;
     }
+
+    public function testExecuteReturnsFalseForNonZeroExit(): void
+    {
+        $adapter = new class () extends DockerAPI {
+            /**
+             * @var array<int, array{response: mixed, code: mixed}>
+             */
+            private array $responses = [
+                ['response' => '{"Id":"exec-id"}', 'code' => 201],
+                ['response' => '{"Running":false,"ExitCode":1}', 'code' => 200],
+            ];
+
+            protected function call(string $url, string $method, $body = null, array $headers = [], int $timeout = -1): array
+            {
+                return \array_shift($this->responses);
+            }
+
+            protected function streamCall(string $url, int $timeout = -1): array
+            {
+                return [
+                    'response' => '',
+                    'code' => 200,
+                    'stdout' => 'command output',
+                    'stderr' => '',
+                ];
+            }
+        };
+
+        $output = '';
+
+        $response = $adapter->execute(
+            'TestContainer',
+            [
+                'php',
+                'doesnotexist.php',
+            ],
+            $output,
+            [
+                'test' => 'testEnviromentVariable',
+            ],
+            1
+        );
+
+        $this->assertFalse($response);
+        $this->assertSame('command output', $output);
+    }
 }


### PR DESCRIPTION
## What changed

- Return `false` from `DockerAPI::execute()` when Docker reports that an exec completed with a non-zero exit code.
- Continue throwing orchestration exceptions for cases where Docker could not reliably create, start, stream, or inspect the exec.
- Add a Docker API regression test using a fake adapter response, so the non-zero exec behavior is covered without relying on the container integration test dependency chain.

## Reasoning

A non-zero exit code means Docker successfully ran the command and reported its outcome. That is different from an orchestration failure.

For example, these should remain exceptional because the orchestration layer failed to perform or observe the operation:

- the container does not exist or is not running
- Docker cannot create the exec instance
- Docker cannot start or stream the exec
- Docker cannot inspect the exec result
- Docker returns an unexpected API response

But once Docker returns an inspected exec result with `Running === false` and `ExitCode !== 0`, the command has completed normally from the orchestrator's perspective. The command failed, but orchestration did not.

The current API returns `bool`, so `false` is the smallest contract-consistent way to expose that completed command failure. A richer long-term API could return a structured result with stdout, stderr, and exit code, but this change keeps the existing method shape and lets callers distinguish user command failures from Docker/API failures.

This matters for callers like executor, where a user build command exiting non-zero should become a build failure, while Docker/API problems should remain runtime or orchestration failures.

## Validation

- `composer lint`
- `./vendor/bin/phpunit --configuration phpunit.xml --filter testExecuteReturnsFalseForNonZeroExit`
